### PR TITLE
bugfix: endless loop when providing specific output times

### DIFF
--- a/source/common_parameters.i
+++ b/source/common_parameters.i
@@ -1,7 +1,7 @@
       integer mxl
       parameter(mxl=1000)
 
-      double precision depth,dt,t_start,t_end
+      double precision depth,dt,dt_0,t_start,t_end
       double precision pi,g,cp,rho_0,rho_air,kappa,K_s,z0,Prndtl
       double precision k_min,eps_min,avh_min
       double precision sig_e,sig_k,ce1,ce2,ce3,cde,cmue,cm0

--- a/source/simstrat.f90
+++ b/source/simstrat.f90
@@ -135,11 +135,16 @@ subroutine simstrat_simulation()
 
     gamma = Az(xl)/(volume**1.5)/sqrt(rho_0)*CD
 
+    std=0
+    step=0
+    itera=0
+    iav=0
+
     if (write_tout==0) then     !if output is written at specific times (irregularly)
         if (tout_ctr2(0)==0) then           ! if first required output time is initial time
             if(disp_sim==1) write(6,990) datum,T(xl),T(xl-5)
             !call write_out(datum,u,v,T,S,k,eps,num,nuh,B,P,NN,P_Seiche,E_Seiche,zu,M)
-            call write_out(datum,u,v,T,S,k,eps,num,nuh,B,P,NN,P_Seiche,E_Seiche,zu)
+            !call write_out(datum,u,v,T,S,k,eps,num,nuh,B,P,NN,P_Seiche,E_Seiche,zu)
             itera=0
             step=1
         end if
@@ -166,10 +171,8 @@ subroutine simstrat_simulation()
         call write_text(datum,U,V,T,S,k,eps,nuh,B,P,NN,P_Seiche,E_Seiche,zu(0:xl),zk(0:xl),Qvert)
     end if
 
-    std=0
-    step=0
-    itera=0
-    iav=0
+    dt_0 = dt
+    
     ! START OF SIMULATION LOOP
     do while (datum<t_end)
         std=std+1
@@ -181,6 +184,7 @@ subroutine simstrat_simulation()
                 itera=0
                 step=step+1
             end if
+            if(dt==0) dt=dt_0
         end if
 
         datum = datum + dt/86400


### PR DESCRIPTION
This should resolve the issues mentioned when providing specific output times