### PR TITLE
Missing parenthesis in strat_temp.f90

### DIFF
--- a/src/strat_temp.f90
+++ b/src/strat_temp.f90
@@ -73,7 +73,7 @@ contains
 
          ! Set boundary heat flux at surface (Eq 25, Goudsmit(2002))
          ! FB, 2021: Correction of relevant area (accoring to tests by Ana Ayala)
-         sources(ubnd_vol) = sources(ubnd_vol) + state%heat/rho_0/cp/grid%h(ubnd_vol)*grid%Az(ubnd_fce)/(grid%Az(ubnd_fce) + grid%Az(ubnd_fce - 1)*2)
+         sources(ubnd_vol) = sources(ubnd_vol) + state%heat/rho_0/cp/grid%h(ubnd_vol)*grid%Az(ubnd_fce)/(grid%Az(ubnd_fce) + grid%Az(ubnd_fce - 1))*2
 
          ! No explicit boundary conditions
          boundaries(1:ubnd_vol) = 0


### PR DESCRIPTION
I noticed issues when compiling the newest Simstrat source code as a parenthesis was missing in strat_temp.f90 which gave gfortran problems (probably no error under fort?).

I assume that this line adds the heat flux as
Q/(cp * rho * V) * A
and A is taken as the middle point of the cell? Therefore I added the missing parenthesis to the end of the line:
`sources(ubnd_vol) = sources(ubnd_vol) + state%heat/rho_0/cp/grid%h(ubnd_vol)*grid%Az(ubnd_fce)/(grid%Az(ubnd_fce) + grid%Az(ubnd_fce - 1)*2`
to 
`sources(ubnd_vol) = sources(ubnd_vol) + state%heat/rho_0/cp/grid%h(ubnd_vol)*grid%Az(ubnd_fce)/(grid%Az(ubnd_fce) + grid%Az(ubnd_fce - 1)*2)`