### PR TITLE
Re-add forbear as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/libaed2"]
 	path = lib/libaed2
 	url = https://github.com/AquaticEcoDynamics/libaed2.git
+[submodule "lib/forbear"]
+	path = lib/forbear
+	url = git@github.com:d-vanzo/forbear.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "lib/libaed2"]
 	path = lib/libaed2
 	url = https://github.com/AquaticEcoDynamics/libaed2.git
-[submodule "lib/forbear"]
-	path = lib/forbear
-	url = https://github.com/d-vanzo/forbear.git


### PR DESCRIPTION
The forbear submodule was linking to a non-existent commit. This fix re-adds forbear as a submodule on an existing commit.

In response to #48 